### PR TITLE
Use swift-tools-version 5.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Changed swift tools version to 5.7 so that it can be built with Xcode 14.2 because of a crash problem with Xcode 14.3.
https://developer.apple.com/documentation/xcode-release-notes/xcode-14_3_1-release-notes